### PR TITLE
"Upgrade" persistgraphql to 0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "webpack": "^3.1.0"
   },
   "dependencies": {
-    "persistgraphql": "^0.4.0",
+    "persistgraphql": "^0.3.5",
     "webpack-virtual-modules": "^0.1.7"
   },
   "files": [


### PR DESCRIPTION
Version 0.3.5 was released after 0.4.0 probably because a mistake of the persistgraphql package author when updating the package version number, who released a minor update wanting to release a patch one.